### PR TITLE
[MSFT] Move export tcl functionality into separate pass

### DIFF
--- a/frontends/PyCDE/src/pycde/system.py
+++ b/frontends/PyCDE/src/pycde/system.py
@@ -41,8 +41,9 @@ class System:
 
   PASSES = """
     msft-partition,
-    lower-msft-to-hw{{tops={tops} verilog-file={verilog_file} tcl-file={tcl_file}}},
-    lower-seq-to-sv,hw.module(prettify-verilog),hw.module(hw-cleanup)
+    lower-msft-to-hw{{verilog-file={verilog_file}}},
+    lower-seq-to-sv, hw.module(prettify-verilog), hw.module(hw-cleanup),
+    msft-export-tcl{{tops={tops}, tcl-file={tcl_file}}}
   """
 
   def __init__(self,

--- a/include/circt/Dialect/MSFT/ExportTcl.h
+++ b/include/circt/Dialect/MSFT/ExportTcl.h
@@ -33,7 +33,7 @@ namespace msft {
 class MSFTModuleOp;
 
 /// Export TCL for a specific hw module.
-mlir::LogicalResult exportQuartusTcl(MSFTModuleOp module,
+mlir::LogicalResult exportQuartusTcl(Operation *module,
                                      llvm::StringRef outputFile = "");
 
 } // namespace msft

--- a/include/circt/Dialect/MSFT/MSFTPasses.td
+++ b/include/circt/Dialect/MSFT/MSFTPasses.td
@@ -11,11 +11,19 @@ def LowerToHW: Pass<"lower-msft-to-hw", "mlir::ModuleOp"> {
   let constructor = "circt::msft::createLowerToHWPass()";
   let dependentDialects = ["circt::sv::SVDialect", "circt::hw::HWDialect"];
   let options = [
+    Option<"verilogFile", "verilog-file", "std::string",
+           "", "File to output Verilog into">,
+  ];
+}
+
+def ExportTcl: Pass<"msft-export-tcl", "mlir::ModuleOp"> {
+  let summary = "Create tcl ops";
+  let constructor = "circt::msft::createExportTclPass()";
+  let dependentDialects = ["circt::sv::SVDialect", "circt::hw::HWDialect"];
+  let options = [
     ListOption<"tops", "tops", "std::string",
                "List of top modules to export Tcl for",
 	       "llvm::cl::ZeroOrMore, llvm::cl::MiscFlags::CommaSeparated">,
-    Option<"verilogFile", "verilog-file", "std::string",
-           "", "File to output Verilog into">,
     Option<"tclFile", "tcl-file", "std::string",
            "", "File to output Tcl into">
   ];

--- a/integration_test/Bindings/Python/dialects/msft.py
+++ b/integration_test/Bindings/Python/dialects/msft.py
@@ -110,9 +110,6 @@ with ir.Context() as ctx, ir.Location.unknown():
       [ir.FlatSymbolRefAttr.get(entity_extern.sym_name.value)])
   rc = seeded_pdb.add_placement(physAttr2, external_path, "", entity_extern)
   assert rc
-  with ir.InsertionPoint(m.body):
-    global_ref = hw.GlobalRefOp(ir.StringAttr.get("foo"), path)
-    global_ref = hw.GlobalRefOp(ir.StringAttr.get("bar"), external_path)
 
   nearest = seeded_pdb.get_nearest_free_in_column(msft.M20K, 2, 4)
   assert isinstance(nearest, msft.PhysLocationAttr)
@@ -256,6 +253,7 @@ with ir.Context() as ctx, ir.Location.unknown():
 
   # CHECK: proc top_config { parent } {
   # BROKEN:   set_location_assignment M20K_X2_Y6_N1 -to $parent|inst1|ext1|foo_subpath
-  pm = mlir.passmanager.PassManager.parse("lower-msft-to-hw{tops=top}")
+  pm = mlir.passmanager.PassManager.parse(
+      "lower-msft-to-hw,msft-export-tcl{tops=top}")
   pm.run(m)
   circt.export_verilog(m, sys.stdout)

--- a/lib/Dialect/MSFT/ExportQuartusTcl.cpp
+++ b/lib/Dialect/MSFT/ExportQuartusTcl.cpp
@@ -172,7 +172,7 @@ static bool isEntityExtern(Operation *op) {
 /// Write out all the relevant tcl commands. Create one 'proc' per module which
 /// takes the parent entity name since we don't assume that the created module
 /// is the top level for the entire design.
-LogicalResult circt::msft::exportQuartusTcl(MSFTModuleOp hwMod,
+LogicalResult circt::msft::exportQuartusTcl(Operation *hwMod,
                                             StringRef outputFile) {
   // Build up the output Tcl, tracking symbol references in state.
   std::string s;

--- a/lib/Dialect/MSFT/MSFTPasses.cpp
+++ b/lib/Dialect/MSFT/MSFTPasses.cpp
@@ -87,6 +87,7 @@ InstanceOpLowering::matchAndRewrite(InstanceOp msftInst, OpAdaptor adaptor,
       SmallVector<Value>(adaptor.getOperands().begin(),
                          adaptor.getOperands().end()),
       msftInst.parameters().getValueOr(ArrayAttr()), msftInst.sym_nameAttr());
+  hwInst->setDialectAttrs(msftInst->getDialectAttrs());
   rewriter.replaceOp(msftInst, hwInst.getResults());
   return success();
 }
@@ -215,16 +216,6 @@ void LowerToHWPass::runOnOperation() {
   auto top = getOperation();
   auto *ctxt = &getContext();
 
-  // Traverse MSFT location attributes and export the required Tcl into
-  // templated `sv::VerbatimOp`s with symbolic references to the instance paths.
-  for (auto moduleName : tops) {
-    auto hwmod = top.lookupSymbol<msft::MSFTModuleOp>(moduleName);
-    if (!hwmod)
-      continue;
-    if (failed(exportQuartusTcl(hwmod, tclFile)))
-      return signalPassFailure();
-  }
-
   // The `hw::InstanceOp` (which `msft::InstanceOp` lowers to) convenience
   // builder gets its argNames and resultNames from the `hw::HWModuleOp`. So we
   // have to lower `msft::MSFTModuleOp` before we lower `msft::InstanceOp`.
@@ -232,8 +223,7 @@ void LowerToHWPass::runOnOperation() {
   // Convert everything except instance ops first.
 
   ConversionTarget target(*ctxt);
-  target.addIllegalOp<MSFTModuleOp, MSFTModuleExternOp, OutputOp,
-                      hw::GlobalRefOp>();
+  target.addIllegalOp<MSFTModuleOp, MSFTModuleExternOp, OutputOp>();
   target.addLegalDialect<hw::HWDialect>();
   target.addLegalDialect<sv::SVDialect>();
 
@@ -241,8 +231,6 @@ void LowerToHWPass::runOnOperation() {
   patterns.insert<ModuleOpLowering>(ctxt, verilogFile);
   patterns.insert<ModuleExternOpLowering>(ctxt, verilogFile);
   patterns.insert<OutputOpLowering>(ctxt);
-  patterns.insert<RemoveOpLowering<msft::PhysLocationOp>>(ctxt);
-  patterns.insert<RemoveOpLowering<hw::GlobalRefOp>>(ctxt);
   patterns.insert<RemoveOpLowering<EntityExternOp>>(ctxt);
   patterns.insert<RemoveOpLowering<DesignPartitionOp>>(ctxt);
 
@@ -250,17 +238,11 @@ void LowerToHWPass::runOnOperation() {
     signalPassFailure();
 
   // Then, convert the InstanceOps
-  target.addIllegalOp<msft::InstanceOp>();
+  target.addDynamicallyLegalDialect<MSFTDialect>(
+      [](Operation *op) { return isa<PhysLocationOp, PhysicalRegionOp>(op); });
   RewritePatternSet instancePatterns(ctxt);
   instancePatterns.insert<InstanceOpLowering>(ctxt);
   if (failed(applyPartialConversion(top, target, std::move(instancePatterns))))
-    signalPassFailure();
-
-  // Finally, legalize the rest of the MSFT dialect.
-  target.addIllegalDialect<MSFTDialect>();
-  RewritePatternSet finalPatterns(ctxt);
-  finalPatterns.insert<RemoveOpLowering<PhysicalRegionOp>>(ctxt);
-  if (failed(applyPartialConversion(top, target, std::move(finalPatterns))))
     signalPassFailure();
 }
 
@@ -271,6 +253,90 @@ std::unique_ptr<Pass> createLowerToHWPass() {
 }
 } // namespace msft
 } // namespace circt
+
+//===----------------------------------------------------------------------===//
+// Export tcl -- create tcl verbatim ops
+//===----------------------------------------------------------------------===//
+
+namespace {
+template <typename PhysOpTy>
+struct RemovePhysOpLowering : public OpConversionPattern<PhysOpTy> {
+  using OpAdaptor = typename OpConversionPattern<PhysOpTy>::OpAdaptor;
+
+  RemovePhysOpLowering(MLIRContext *ctxt, DenseSet<SymbolRefAttr> &refsUsed)
+      : OpConversionPattern<PhysOpTy>::OpConversionPattern(ctxt),
+        refsUsed(refsUsed) {}
+
+  LogicalResult
+  matchAndRewrite(PhysOpTy op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    SymbolRefAttr refSym = op->template getAttrOfType<FlatSymbolRefAttr>("ref");
+    if (refSym)
+      refsUsed.insert(refSym);
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+private:
+  DenseSet<SymbolRefAttr> &refsUsed;
+};
+} // anonymous namespace
+
+namespace {
+struct ExportTclPass : public ExportTclBase<ExportTclPass> {
+  void runOnOperation() override;
+};
+} // anonymous namespace
+
+void ExportTclPass::runOnOperation() {
+  auto top = getOperation();
+  auto *ctxt = &getContext();
+
+  // Traverse MSFT location attributes and export the required Tcl into
+  // templated `sv::VerbatimOp`s with symbolic references to the instance paths.
+  for (auto moduleName : tops) {
+    auto hwmod = top.lookupSymbol(moduleName);
+    if (!hwmod)
+      continue;
+    if (failed(exportQuartusTcl(hwmod, tclFile)))
+      return signalPassFailure();
+  }
+
+  ConversionTarget target(*ctxt);
+  target.addIllegalDialect<msft::MSFTDialect>();
+  target.addLegalDialect<hw::HWDialect>();
+  target.addLegalDialect<sv::SVDialect>();
+
+  RewritePatternSet patterns(ctxt);
+  DenseSet<SymbolRefAttr> refsUsed;
+  patterns.insert<RemovePhysOpLowering<PhysLocationOp>>(ctxt, refsUsed);
+  patterns.insert<RemoveOpLowering<PhysicalRegionOp>>(ctxt);
+  if (failed(applyPartialConversion(top, target, std::move(patterns))))
+    signalPassFailure();
+
+  target.addDynamicallyLegalOp<hw::GlobalRefOp>([&](hw::GlobalRefOp ref) {
+    return !refsUsed.contains(SymbolRefAttr::get(ref)) &&
+           llvm::none_of(ref->getAttrs(), [](NamedAttribute attr) {
+             return attr.getValue().isa<PhysicalRegionRefAttr>();
+           });
+  });
+  patterns.clear();
+  patterns.insert<RemoveOpLowering<hw::GlobalRefOp>>(ctxt);
+  if (failed(applyPartialConversion(top, target, std::move(patterns))))
+    signalPassFailure();
+}
+
+namespace circt {
+namespace msft {
+std::unique_ptr<Pass> createExportTclPass() {
+  return std::make_unique<ExportTclPass>();
+}
+} // namespace msft
+} // namespace circt
+
+//===----------------------------------------------------------------------===//
+// Wire and partitioning passes
+//===----------------------------------------------------------------------===//
 
 namespace {
 struct PassCommon {

--- a/test/Dialect/MSFT/location.mlir
+++ b/test/Dialect/MSFT/location.mlir
@@ -1,6 +1,6 @@
 // RUN: circt-opt %s -verify-diagnostics | circt-opt -verify-diagnostics | FileCheck %s
-// RUN: circt-opt %s --lower-msft-to-hw=tops=shallow,deeper,regions,reg --lower-seq-to-sv | FileCheck %s --check-prefix=LOWER
-// RUN: circt-opt %s --lower-msft-to-hw=tops=shallow,deeper,regions,reg --lower-seq-to-sv --export-verilog | FileCheck %s --check-prefix=TCL
+// RUN: circt-opt %s --lower-msft-to-hw --lower-seq-to-sv --msft-export-tcl=tops=shallow,deeper,regions,reg | FileCheck %s --check-prefix=LOWER
+// RUN: circt-opt %s --lower-msft-to-hw --lower-seq-to-sv --msft-export-tcl=tops=shallow,deeper,regions,reg --export-verilog | FileCheck %s --check-prefix=TCL
 
 hw.globalRef @ref1 [#hw.innerNameRef<@deeper::@branch>, #hw.innerNameRef<@shallow::@leaf>, #hw.innerNameRef<@leaf::@module>]
 msft.pd.location @ref1 <M20K, 15, 9, 3> path: "memBank2"

--- a/test/Dialect/MSFT/translate-errors.mlir
+++ b/test/Dialect/MSFT/translate-errors.mlir
@@ -1,4 +1,4 @@
-// RUN: circt-opt %s --lower-msft-to-hw=tops=top -verify-diagnostics -split-input-file
+// RUN: circt-opt %s --lower-msft-to-hw --msft-export-tcl=tops=top -verify-diagnostics -split-input-file
 
 hw.module.extern @Foo()
 


### PR DESCRIPTION
Allow export tcl to be run later in the pass pipeline to allow passes
in between to modify the hierarchy.